### PR TITLE
Add CHANGELOG.md for project change tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- CHANGELOG.md file to track project changes
+
+## [1.0.0] - 2025-11-14
+
+### Initial Release
+- Flask-based TODO list application
+- Unit and integration tests using Robot Framework
+- Docker support for containerized deployment


### PR DESCRIPTION
## Summary
This PR adds a CHANGELOG.md file to track project changes and improvements over time.

## Changes
- Added `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format
- Documented initial release and current project state
- Set up structure for future changelog entries

## Benefits
- Better project documentation
- Easier tracking of changes and versions
- Improved transparency for contributors and users

## Related
N/A - Initial changelog addition